### PR TITLE
fix: support jasmine.anything()

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,7 +7,6 @@ import {
   Subscription,
 } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { isEqual } from 'lodash';
 
 import {
   getTestScheduler,
@@ -126,7 +125,7 @@ export function addMatchers() {
         return { pass: true };
       },
     }),
-    toBeObservable: (_utils, _equalityTester) => ({
+    toBeObservable: (utils, _equalityTester) => ({
       compare: function (actual: TestObservable, fixture: TestObservable) {
         const results: TestMessages = [];
         let subscription: Subscription;
@@ -183,14 +182,14 @@ export function addMatchers() {
           true,
         );
 
-        if (isEqual(results, expected)) {
+        if (utils.equals(results, expected)) {
           return { pass: true };
         }
 
         const mapNotificationToSymbol = buildNotificationToSymbolMapper(
           fixture.marbles,
           expected,
-          isEqual,
+          (a: any, b: any) => utils.equals(a, b),
         );
         const receivedMarble = unparseMarble(results, mapNotificationToSymbol);
 

--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -113,4 +113,11 @@ describe('Integration', () => {
 
     expect(provided).not.toBeObservable(expected);
   });
+
+  it('should support jasmine.anything()', () => {
+    const provided = cold('a', { a: { someProp: 3 } });
+    const expected = cold('a', { a: jasmine.anything() });
+
+    expect(provided).toBeObservable(expected);
+  });
 });


### PR DESCRIPTION
This basically reverts #65 and uses `jasmine.MatchersUtil.equals()` for comparing which supports `jasmine.anything()`.

But I don't understand how this library is used in a Jest environment, what #65 was targeted for. In `addMatchers()` only custom matchers are added to jasmine, not Jest. Can you clarify your use case? I want to avoid any regression.

Closes #66