### PR TITLE
fix: display differences when comparison includes undefined values

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -216,15 +216,22 @@ function formatMessage(
   receivedMarbles: string,
   receivedMessages: TestMessages,
 ) {
+  /**
+   * Undefined values are stripped with JSON.stringify,
+   * so we substitute them with placeholder text,
+   * and convert back to undefined visually for comparison.
+   */
+  const replacer = (key: string, value: string) => (value === undefined) ? '__undefined' : value;
+
   return `
     Expected: ${expectedMarbles},
     Received: ${receivedMarbles},
     
     Expected:
-    ${JSON.stringify(expectedMessages)}
+    ${JSON.stringify(expectedMessages, replacer).replace(/"__undefined"/g, 'undefined')}
     
     Received:
-    ${JSON.stringify(receivedMessages)},
+    ${JSON.stringify(receivedMessages, replacer).replace(/"__undefined"/g, 'undefined')}
   `;
 }
 

--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -113,4 +113,14 @@ describe('Integration', () => {
 
     expect(provided).not.toBeObservable(expected);
   });
+
+  it('should support comparison with undefined values', () => {
+    const data = { value: 1, included: undefined };
+    const result = { type: 'test', data };
+    const provided = of(result);
+
+    const expected = cold('(b|)', { b: { type: 'test', data: { value: 1 } }});
+
+    expect(provided).not.toBeObservable(expected);
+  });
 });


### PR DESCRIPTION
JSON.stringify strips keys with a value of `undefined`. If that's the only differences in the expected vs the result, it doesn't provide a helpful parsed diagram for error reporting.