### PR TITLE
fix: fix comparison for undefined properties and value matchers with Jasmine and Jest

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -154,24 +154,27 @@ const toBeObservableComparer = function (
     true,
   );
 
-  if (isEqual(results, expected)) {
+  try {
+    expect(results).toEqual(expected);
+
     return { pass: true, message: () => '' };
+  } catch (e) {
+    const mapNotificationToSymbol = buildNotificationToSymbolMapper(
+      fixture.marbles,
+      expected,
+      isEqual,
+    );
+    const receivedMarble = unparseMarble(results, mapNotificationToSymbol);
+
+    const message = formatMessage(
+      fixture.marbles,
+      expected,
+      receivedMarble,
+      results,
+    );
+
+    return { pass: false, message: () => message };
   }
-
-  const mapNotificationToSymbol = buildNotificationToSymbolMapper(
-    fixture.marbles,
-    expected,
-    isEqual,
-  );
-  const receivedMarble = unparseMarble(results, mapNotificationToSymbol);
-
-  const message = formatMessage(
-    fixture.marbles,
-    expected,
-    receivedMarble,
-    results,
-  );
-  return { pass: false, message: () => message };
 };
 
 export function addMatchers() {

--- a/spec/integration.spec.ts
+++ b/spec/integration.spec.ts
@@ -10,6 +10,7 @@ import {
   resetTestScheduler,
   time,
 } from '../index';
+import { TestColdObservable } from '../src/test-observables';
 
 describe('Integration', () => {
   it('should work with a cold observable', () => {
@@ -112,5 +113,50 @@ describe('Integration', () => {
     const expected = cold('(b|)', { b: 2 });
 
     expect(provided).not.toBeObservable(expected);
+  });
+
+  it('should support undefined values', () => {
+    const provided = of({ myValue: 1, someOtherVal: undefined });
+
+    const expected = cold('(b|)', { b: { myValue: 1 } });
+
+    expect(provided).toBeObservable(expected);
+  });
+
+  it('should support jasmine.anything()', () => {
+    if ((globalThis as any).jasmine) {
+      const provided = cold('a', { a: { someProp: 3 } });
+      const expected = cold('a', { a: jasmine.anything() });
+
+      expect(provided).toBeObservable(expected);
+    }
+  });
+
+  it('should support expect.any()', () => {
+    if (!(globalThis as any).jasmine) {
+      const provided = cold('a', { a: { someProp: 'message' } });
+      const expected = cold('a', { a: { someProp: expect.any(String) } });
+
+      expect(provided).toBeObservable(expected);
+    }
+  });
+
+  it('should support objectContaining()', () => {
+    const provided = cold('a', {
+      a: { foo: 'bar', value: '1', type: 'myType' },
+    });
+    let expected: TestColdObservable;
+
+    if ((globalThis as any).jasmine) {
+      expected = cold('b', {
+        b: jasmine.objectContaining({ value: '1', type: 'myType' }),
+      });
+    } else {
+      expected = cold('b', {
+        b: expect.objectContaining({ value: '1', type: 'myType' }),
+      });
+    }
+
+    expect(provided).toBeObservable(expected);
   });
 });


### PR DESCRIPTION
The introduction of #55 added better error reporting for marble diagrams. A side effect of that was that undefined values were used in the assertion comparison. The undefined values were also stripped out from the error message.

The following example should pass, but failed

```ts
    const provided = of({ myValue: 1, someOtherVal: undefined });

    const expected = cold('(b|)', { b: { myValue: 1 } });

    expect(provided).toBeObservable(expected);
```
This fixes issues with asserting with undefined values and using value matchers including.

- jasmine.anything
- jasmine.objectContaining
- expect.any
- expect.objectContaining

Closes #66, #76, #84, #85