### PR TITLE
fix: replace limitted JSON.stringify with better formatter

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "rxjs": "^7.0.0"
   },
   "dependencies": {
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.20",
+    "pretty-format": "^27.4.2"
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,6 +8,7 @@ import {
 } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { isEqual } from 'lodash';
+import { format as prettyFormat } from 'pretty-format';
 import { getTestScheduler } from './scheduler';
 import { TestObservable } from './test-observables';
 import { mapSymbolsToNotifications } from './map-symbols-to-notifications';
@@ -182,13 +183,13 @@ function formatMessage(
   receivedMessages: TestMessages,
 ) {
   return `
-    Expected: ${expectedMarbles},
-    Received: ${receivedMarbles},
+Expected: ${expectedMarbles},
+Received: ${receivedMarbles},
     
-    Expected:
-    ${JSON.stringify(expectedMessages)}
+Expected:
+${prettyFormat(expectedMessages)}
     
-    Received:
-    ${JSON.stringify(receivedMessages)},
+Received:
+${prettyFormat(receivedMessages)}
   `;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1299,6 +1299,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.4.2":
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.4.2.tgz#96536ebd34da6392c2b7c7737d693885b5dd44a5"
+  integrity sha512-j35yw0PMTPpZsUoOBiuHzr1zTYoad1cVIE0ajEjcrJONxxrko/IRGKkXx3os0Nsi4Hu3+5VmDbVfq5WhG/pWAg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -1495,6 +1506,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.1.0:
   version "3.2.0"
@@ -4055,6 +4071,16 @@ pretty-format@^27.0.6:
   dependencies:
     "@jest/types" "^27.0.6"
     ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.4.2:
+  version "27.4.2"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.4.2.tgz#e4ce92ad66c3888423d332b40477c87d1dac1fb8"
+  integrity sha512-p0wNtJ9oLuvgOQDEIZ9zQjZffK7KtyR6Si0jnXULIDwrlNF8Cuir3AZP0hHv0jmKuNN/edOnbMjnzd4uTcmWiw==
+  dependencies:
+    "@jest/types" "^27.4.2"
+    ansi-regex "^5.0.1"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"
 


### PR DESCRIPTION
Prior to this change expected and received data structures were printed
via using the JSON.stringify method to console. However this method is
limited by the fact that it doesn't support enhanced data types like Map,
Set, etc. except when using a replacer function.